### PR TITLE
Support varargs log events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const util = require('util');
 
 module.exports = () => {
   // initialize arrays for all levels
@@ -11,7 +12,16 @@ module.exports = () => {
     get: (layer) => {
       // add error(msg), info(msg), etc to getLayer() to form logger functionality
       return Object.keys(levels).reduce((acc, level) => {
-        return _.set(acc, level, msg => levels[level].push(msg));
+        return _.set(acc, level, function() {
+          // add a function to $level that 'apply's to util.format
+          levels[level].push(
+            util.format.apply(
+              null,
+              // convert arguments to an array
+              Array.prototype.slice.call(arguments)
+            )
+          );
+        });
       }, { getLayer: () => layer } );
     },
     // return the supported logging levels

--- a/test/index.js
+++ b/test/index.js
@@ -35,14 +35,12 @@ test('varargs should be supported for logging events (util.format gets called un
   const logger = rootLogger.get('layer value');
 
   rootLogger.getLevels().forEach(level => {
-    logger[level](`${level} message %d %d`, 1, 2, { a: 3 }, [4, 5]);
-    logger[level](`${level} message %d %d`, 6, 7, { b: 8 }, [9, 10]);
+    logger[level](`${level} message %d %s`, 1, 'blah', { a: 3 }, [4, 5]);
 
     const actual = rootLogger.getMessages(level);
 
     const expected = [
-      `${level} message 1 2 { a: 3 } [ 4, 5 ]`,
-      `${level} message 6 7 { b: 8 } [ 9, 10 ]`
+      `${level} message 1 blah { a: 3 } [ 4, 5 ]`,
     ];
 
     t.deepEquals(actual, expected, `all ${level} messages should have been returned`);

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,47 @@ test('all levels should initially be empty', (t) => {
 
 });
 
+test('varargs should be supported for logging events (util.format gets called under the hood)', t => {
+  const rootLogger = require('../index')();
+  const logger = rootLogger.get('layer value');
+
+  rootLogger.getLevels().forEach(level => {
+    logger[level](`${level} message %d %d`, 1, 2, { a: 3 }, [4, 5]);
+    logger[level](`${level} message %d %d`, 6, 7, { b: 8 }, [9, 10]);
+
+    const actual = rootLogger.getMessages(level);
+
+    const expected = [
+      `${level} message 1 2 { a: 3 } [ 4, 5 ]`,
+      `${level} message 6 7 { b: 8 } [ 9, 10 ]`
+    ];
+
+    t.deepEquals(actual, expected, `all ${level} messages should have been returned`);
+
+  });
+
+  t.end();
+
+});
+
+test('0-parameter logging event calls should log empty strings', t => {
+  const rootLogger = require('../index')();
+  const logger = rootLogger.get('layer value');
+
+  rootLogger.getLevels().forEach(level => {
+    // log nothing
+    logger[level]();
+
+    const actual = rootLogger.getMessages(level);
+
+    t.deepEquals(actual, [''], 'empty string should have been logged');
+
+  });
+
+  t.end();
+
+});
+
 // TESTS FOR GET
 test('getMessages should return all messages logged at the specified level', (t) => {
   const rootLogger = require('../index')();


### PR DESCRIPTION
This allows pelias-mock-logger to test things like:

```
logger.info('my message %d %s', 1, 'blah', { a: 3 }, [4, 5]);
// which logs: my message 1 blah { a: 3 } [ 4, 5 ]
```

The logger module calls `util.format` under the hood, so this PR mimics that behavior.  Previously, all parameters other than the first would be ignored.  