### PR TITLE
throw instances of Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = () => {
         return _.cloneDeep(levels);
       }
 
-      throw `unsupported log level: ${level}`;
+      throw new Error(`unsupported log level: ${level}`);
     },
     isMessage: (level, pattern) => {
       if (levels.hasOwnProperty(level)) {
@@ -51,10 +51,10 @@ module.exports = () => {
             _.isRegExp(pattern) ? message.match(pattern) : message === pattern);
         }
 
-        throw 'pattern must be a regexp or string';
+        throw new Error('pattern must be a regexp or string');
       }
 
-      throw `unsupported log level: ${level}`;
+      throw new Error(`unsupported log level: ${level}`);
     }
   };
 

--- a/test/index.js
+++ b/test/index.js
@@ -165,7 +165,7 @@ test('unknown level parameter to getMessages should throw error', (t) => {
 
   t.throws(
     rootLogger.getMessages.bind(null, 'unknown level'),
-    /^unsupported log level: unknown level$/
+    /^Error: unsupported log level: unknown level$/
   );
   t.end();
 
@@ -220,7 +220,7 @@ test('unknown level parameter to hasMessages should throw error', (t) => {
 
   t.throws(
     rootLogger.hasMessages.bind(null, 'unknown level'),
-    /^unsupported log level: unknown level$/
+    /^Error: unsupported log level: unknown level$/
   );
   t.end();
 
@@ -281,11 +281,11 @@ test('isMessage should throw an error if the supplied pattern is not a valid reg
   rootLogger.getLevels().forEach((level) => {
     t.throws(
       rootLogger.isMessage.bind(null, level, 17.3),
-      /^pattern must be a regexp or string$/
+      /^Error: pattern must be a regexp or string$/
     );
     t.throws(
       rootLogger[`is${_.capitalize(level)}Message`].bind(null, 17.3),
-      /^pattern must be a regexp or string$/
+      /^Error: pattern must be a regexp or string$/
     );
   });
 
@@ -298,7 +298,7 @@ test('unknown level parameter to isMessage should throw error', (t) => {
 
   t.throws(
     rootLogger.isMessage.bind(null, 'unknown level'),
-    /^unsupported log level: unknown level$/
+    /^Error: unsupported log level: unknown level$/
   );
   t.end();
 


### PR DESCRIPTION
as discussed in https://github.com/pelias/mock-logger/issues/22 this PR throws instances of `Error` instead of strings.